### PR TITLE
add stream support

### DIFF
--- a/src/esio.erl
+++ b/src/esio.erl
@@ -17,7 +17,8 @@
    put/3, put/4, put_/3, put_/4,
    get/2, get/3, get_/2, get_/3,
    remove/2, remove/3, remove_/2, remove_/3,
-   lookup/2, lookup/3, lookup/4, lookup_/2, lookup_/3, lookup_/4
+   lookup/2, lookup/3, lookup/4, lookup_/2, lookup_/3, lookup_/4,
+   stream/2, stream/3
 ]).
 
 %%
@@ -134,7 +135,7 @@ remove_(Sock, Key, Flag) ->
 -spec lookup(sock(), key(), req(), timeout()) -> {ok, val()} | {error, _}.
 
 lookup(Sock, Query) ->
-   lookup(Sock, {urn, <<"esio">>, <<"*">>}, Query).
+   lookup(Sock, ?WILDCARD, Query).
 
 lookup(Sock, Uid, Query) ->
    lookup(Sock, Uid, Query, ?TIMEOUT).
@@ -149,7 +150,7 @@ lookup(Sock, Uid, Query, Timeout) ->
 -spec lookup_(sock(), key(), req(), boolean()) -> ok | reference().
 
 lookup_(Sock, Query) ->
-   lookup_(Sock, {urn, <<"esio">>, <<"*">>}, Query).
+   lookup_(Sock, ?WILDCARD, Query).
 
 lookup_(Sock, Uid, Query) ->
    lookup_(Sock, Uid, Query, true).
@@ -157,6 +158,17 @@ lookup_(Sock, Uid, Query) ->
 lookup_(Sock, Uid, Query, Flag) ->
    req_(Sock, {lookup, uri:new(Uid), jsx:encode(Query)}, Flag).
    
+
+%%
+%% return data stream corresponding to query
+-spec stream(sock(), req()) -> datum:stream(). 
+-spec stream(sock(), key(), req()) -> datum:stream(). 
+
+stream(Sock, Query) ->
+   stream(Sock, ?WILDCARD, Query).
+
+stream(Sock, Uid, Query) ->
+   esio_stream:new(Sock, Uid, Query).
 
 
 %%-----------------------------------------------------------------------------

--- a/src/esio.hrl
+++ b/src/esio.hrl
@@ -8,3 +8,11 @@
 %%
 %% default i/o timeout
 -define(TIMEOUT, 5000).
+
+%%
+%% wild-card urn, matches any indexes
+-define(WILDCARD,  {urn, <<"esio">>, <<"*">>}).
+
+%%
+%% number of elements to read
+-define(CONFIG_STREAM_CHUNK,  100).

--- a/src/esio_stream.erl
+++ b/src/esio_stream.erl
@@ -1,0 +1,52 @@
+%%
+%%   Copyright (C) 2016 Zalando SE
+%%
+%%   This software may be modified and distributed under the terms
+%%   of the MIT license.  See the LICENSE file for details.
+%%
+%% @doc
+%%   stream is continues query, it is designed as functional stream with side-effect
+-module(esio_stream). 
+-include("esio.hrl").
+
+-export([new/3]).
+
+%%
+%% 
+new(Sock, Uid, Query) ->
+   stream:takewhile(
+      fun(X) -> X =/= eos end,
+      stream:unfold(fun unfold/1, 
+         #{
+            state => [], 
+            sock  => Sock, 
+            uid   => Uid, 
+            q     => Query#{from => 0, size => ?CONFIG_STREAM_CHUNK}
+         }
+      )
+   ).
+   
+%%
+%%
+unfold(#{state := [], q := #{from := From} = Query} = Seed) ->
+   case lookup(Seed) of
+      {ok, #{<<"hits">> := []}} ->
+         {eos, Seed};
+
+      {ok, #{<<"hits">> := Hits}} ->
+         unfold(
+            Seed#{
+               state => Hits, 
+               q     => Query#{from => From + length(Hits)}
+            }
+         )
+   end;   
+
+unfold(#{state := [H|T]} = Seed) ->
+   {H, Seed#{state := T}}. 
+
+%%
+%%
+lookup(#{sock := Sock, uid := Uid, q := Query}) ->
+   esio:lookup(Sock, Uid, Query).
+

--- a/test/esio_keyval_SUITE.erl
+++ b/test/esio_keyval_SUITE.erl
@@ -18,6 +18,9 @@
 -export([
    put/1, get/1, remove/1, lookup/1
 ]).
+-export([
+   stream/1
+]).
 
 %%%----------------------------------------------------------------------------   
 %%%
@@ -27,13 +30,17 @@
 
 all() ->
    [
-      {group, keyval}
+      {group, keyval},
+      {group, stream}
    ].
 
 groups() ->
    [
       {keyval, [parallel], [
          put, get, remove, lookup
+      ]},
+      {stream, [parallel], [
+         stream
       ]}
    ].
 
@@ -136,6 +143,15 @@ lookup(Config) ->
 
    esio:close(Sock).
 
+
+stream(Config) ->
+   {ok, Sock} = esio:socket( ?config(elastic_search_url, Config) ),
+   Urn = ?config(base, Config),
+
+   Stream  = esio:stream(Sock, Urn, #{'query' => #{'match_all' => #{}} }),
+   [_ | _] = stream:list(Stream),
+
+   esio:close(Sock).
 
 
 %%%----------------------------------------------------------------------------   


### PR DESCRIPTION
wrap query to `datum:stream()` (lazy list). The stream evaluates
query until all data is fetch or process is aborted by client.