### PR TITLE
No assumption on default type/mapping

### DIFF
--- a/src/esio_socket.erl
+++ b/src/esio_socket.erl
@@ -240,8 +240,11 @@ urn_to_cask(Uri, {urn, _, _} = Key) ->
 urn_to_cask(Uri, [_Cask, _Type, _Key] = List) ->
    uri:segments(List, Uri);
 
-urn_to_cask(Uri, [Cask, Key]) ->
-   uri:segments([Cask, <<"default">>, Key], Uri).
+urn_to_cask(Uri, [Cask, Type]) ->
+   uri:segments([Cask, Type], Uri);
+
+urn_to_cask(Uri, [Cask]) ->
+   uri:segments([Cask], Uri).
 
 %%
 %%


### PR DESCRIPTION
the client is responsible to define explicit type/mapping for any
written document