### PR TITLE
app.src: add jsx to applications, add registered names

### DIFF
--- a/src/esio.app.src
+++ b/src/esio.app.src
@@ -3,7 +3,11 @@
       {description, "elastic search i/o"},
       {vsn,         "1.0.0"},
       {modules,     []},
-      {registered,  []},
+      {registered,  [
+         esio_sup
+        ,esio_socket_sup
+        ,esio_socket_bulk_sup
+      ]},
       {applications,[
          kernel
         ,stdlib

--- a/src/esio.app.src
+++ b/src/esio.app.src
@@ -13,6 +13,7 @@
         ,stdlib
         ,lager
         ,knet
+        ,jsx
       ]},
       {mod, {esio_app, []}},
       {env, []}


### PR DESCRIPTION
Changes:

5ced3a9 (J Phani Mahesh, 9 minutes ago)
   add jsx to applications in app.src

   `esio` depends on `jsx` at runtime.  It is a library application without a
   supervision tree, providing only modules whose functions can be called.
   Erlang tooling conventions require library dependencies to be included in
   `applications`. This is used by systools to ensure dependencies are made
   available in the right order, and by release builders to ensure that they
   are bundled into the release.

   Not including this would mean any applications depending on `esio` do not
   work in releases unless `jsx` is added to the release by adding it in
   configuration (reltool,relx, etc) or another dependency luckily includes
   it.

9652459 (J Phani Mahesh, 13 minutes ago)
   add registered process names to app.src

   All names that will be registered by an application should be listed in
   app.src under `registered` key. These will be used by systools to detect
   name clashes between applications and their registered processes when
   building a release.

   It is common practice to namespace all modules and processes by prefixing
   them with the name of application, and thus the chance risk of accidental
   conflicts is minimal. It is however a good idea to ensure that the
   application resource file is as detailed as possible.